### PR TITLE
'networkTime' method now returns NIL if the timeIntervalSinceDeviceTime ...

### DIFF
--- a/src/NetworkClock.h
+++ b/src/NetworkClock.h
@@ -18,6 +18,8 @@
 @interface NetworkClock : NSObject {
 
     NSTimeInterval          timeIntervalSinceDeviceTime;
+    
+    BOOL                    ready;
 
     NSMutableArray *        timeAssociations;
 

--- a/src/NetworkClock.m
+++ b/src/NetworkClock.m
@@ -45,6 +45,9 @@
 
 - (id) init {
     if (!(self = [super init])) return nil;
+    
+    ready = NO;
+    
 /*┌──────────────────────────────────────────────────────────────────────────────────────────────────┐
   │ Prepare a sort-descriptor to sort associations based on their dispersion, and then create an     │
   │ array of empty associations to use ...                                                           │
@@ -101,6 +104,7 @@
 
     if (usefulCount > 0) {
         timeIntervalSinceDeviceTime /= usefulCount;
+        ready = YES;
     }
 //###ADDITION?
   if (usefulCount ==8)
@@ -117,7 +121,7 @@
   ┃ be called very frequently, we recompute the average offset every 30 seconds.                     ┃
   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛*/
 - (NSDate *) networkTime {
-    return [[NSDate date] dateByAddingTimeInterval:-timeIntervalSinceDeviceTime];
+    return ready ? [[NSDate date] dateByAddingTimeInterval:-timeIntervalSinceDeviceTime] : nil;
 
     //[[NSNotificationCenter defaultCenter] postNotificationName:@"net-time" object:self];
 


### PR DESCRIPTION
...has not been calculated yet

I needed a way to tell if the date retrieved by networkTime is the one really from the network or just a "fake".
In this way if the NetworkClock is not ready yet, it will return a nil value indicating that it does not have a valid value yet (it's up on the user to choose if wait for a valid value or just use the regular system date).
