### PR TITLE
Fix bug network time incorrect

### DIFF
--- a/ios-ntp-lib/NetworkClock.m
+++ b/ios-ntp-lib/NetworkClock.m
@@ -87,7 +87,7 @@
   ┃ Return the device clock time adjusted for the offset to network-derived UTC.                     ┃
   ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛*/
 - (NSDate *) networkTime {
-    return [[NSDate date] dateByAddingTimeInterval:[self networkOffset]];
+    return [[NSDate date] dateByAddingTimeInterval:-[self networkOffset]];
 }
 
 - (instancetype) init {


### PR DESCRIPTION
It is the bug, which is double the offset time, because it miss "-" sign.
Solution: should be add "-" sign in getter - (NSDate *) networkTime

Issue:
https://github.com/jbenet/ios-ntp/issues/28