### PR TITLE
Fix circular dependencies, which break ios-ntp when used with Cocoapods/Swift

### DIFF
--- a/ios-ntp-lib/NetAssociation.h
+++ b/ios-ntp-lib/NetAssociation.h
@@ -25,7 +25,7 @@
 
 @end
 
-#import "GCDAsyncUdpSocket.h"
+@protocol GCDAsyncUdpSocketDelegate;
 
 @interface NetAssociation : NSObject <GCDAsyncUdpSocketDelegate, NetAssociationDelegate>
 

--- a/ios-ntp-lib/NetworkClock.m
+++ b/ios-ntp-lib/NetworkClock.m
@@ -8,6 +8,7 @@
 
 #import "NetworkClock.h"
 #import "ntp-log.h"
+#import "GCDAsyncUdpSocket.h"
 
 @interface NetworkClock () {
 
@@ -16,7 +17,7 @@
 
     NSSortDescriptor *      dispersionSortDescriptor;
     dispatch_queue_t        associationDelegateQueue;
-    
+
 }
 
 @end
@@ -50,12 +51,12 @@
 - (NSTimeInterval) networkOffset {
 
     if ([timeAssociations count] == 0) return 0.0;
-    
+
     NSArray *       sortedArray = [timeAssociations sortedArrayUsingDescriptors:sortDescriptors];
 
     double          timeInterval = 0.0;
     short           usefulCount = 0;
-    
+
     for (NetAssociation * timeAssociation in sortedArray) {
         if (timeAssociation.active) {
             if (timeAssociation.trusty) {
@@ -70,11 +71,11 @@
                     [timeAssociation finish];
                 }
             }
-            
+
             if (usefulCount == 8) break;                // use 8 best dispersions
         }
     }
-    
+
     if (usefulCount > 0) {
         timeInterval = timeInterval / usefulCount;
 //      NSLog(@"timeIntervalSinceDeviceTime: %f (%d)", timeInterval*1000.0, usefulCount);
@@ -106,7 +107,7 @@
                                                             selector:@selector(createAssociations)
                                                               object:nil]];
     }
-    
+
     return self;
 }
 


### PR DESCRIPTION
See http://stackoverflow.com/questions/32978592/ios-ntp-with-xcode-7-and-swift-2-0/32979106?noredirect=1#comment55922000_32979106 and http://stackoverflow.com/questions/25670431/how-to-prevent-circular-reference-when-swift-bridging-header-imports-a-file-that/28329497#28329497 for more information. ios-ntp does not build correctly when used with Cocoapods/Swift due to a circular dependency which this PR addresses by forward-declaring the dependency.