### PR TITLE
Avoid 'filter' redefinition.

### DIFF
--- a/ios-ntp-lib/NetAssociation.m
+++ b/ios-ntp-lib/NetAssociation.m
@@ -119,7 +119,7 @@ double ntpDiffSeconds(union ntpTime * start, union ntpTime * stop) {
                                                delegateQueue:dispatch_queue_create(
                    [serverName cStringUsingEncoding:NSUTF8StringEncoding], DISPATCH_QUEUE_SERIAL)];
 
-//        [socket setReceiveFilter:filter withQueue:dispatch_get_main_queue()];
+//        [socket setReceiveFilter:filterBlock withQueue:dispatch_get_main_queue()];
 
 		[self registerObservations];
     }
@@ -408,7 +408,7 @@ double ntpDiffSeconds(union ntpTime * start, union ntpTime * stop) {
 
 #pragma mark                        I n b o u n d • D a t a   F i l t e r
 
-GCDAsyncUdpSocketReceiveFilterBlock filter = ^BOOL (NSData *data, NSData *address, id *context) {
+GCDAsyncUdpSocketReceiveFilterBlock filterBlock = ^BOOL (NSData *data, NSData *address, id *context) {
 
     return TRUE;
 


### PR DESCRIPTION
'filter' is already defined in Apple curses.h file:
extern NCURSES_EXPORT(void) filter (void);              /\* implemented */
