### PR TITLE
Fix podspec

### DIFF
--- a/ios-ntp-lib/NetAssociation.h
+++ b/ios-ntp-lib/NetAssociation.h
@@ -52,7 +52,7 @@ union ntpTime {
 
 } ;
 
-union ntpTime   ntp_time_now();
+union ntpTime   ntp_time_now(void);
 union ntpTime   unix2ntp(const struct timeval * tv);
 double          ntpDiffSeconds(union ntpTime * start, union ntpTime * stop);
 

--- a/ios-ntp.podspec
+++ b/ios-ntp.podspec
@@ -8,8 +8,7 @@ Pod::Spec.new do |s|
   s.author       = { 'Gavin Eadie' => 'https://github.com/gavineadie' }
   s.ios.deployment_target = '7.0'
   s.tvos.deployment_target = '9.0'
-  s.source_files = 'ios-ntp-lib/*.{h,m}'
+  s.source_files = 'ios-ntp-lib/*.{h,m}', 'network-udp/*.{h,m}'
   s.framework = 'CFNetwork'
-  s.dependency 'CocoaAsyncSocket', '~>7.4.1'
   s.requires_arc = true
 end

--- a/network-udp/GCDAsyncUdpSocket.m
+++ b/network-udp/GCDAsyncUdpSocket.m
@@ -1920,7 +1920,7 @@ enum GCDAsyncUdpSocketConfig
 	flags |= kReceive6SourceSuspended;
 }
 
-- (BOOL)createSocket4:(BOOL)useIPv4 socket6:(BOOL)useIPv6 error:(NSError **)errPtr
+- (BOOL)createSocket4:(BOOL)useIPv4 socket6:(BOOL)useIPv6 error:(NSError * __autoreleasing *)errPtr
 {
 	LogTrace();
 	


### PR DESCRIPTION
As discussed in #55, the podspec is broken. This should fix it (passes validation in `pod lib lint ios-ntp.podspec`). I removed unused `CocoaAsyncSocket` dependency and added `network-udp` folder in the spec sources. Then fixed 2 compilation warnings that prevented spec validation.